### PR TITLE
Organise blog posts by date published, support for slugs+date frontmatter

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -28,6 +28,11 @@ const descriptors = [
         name: 'thumbnailCaption',
         getter: node => node.frontmatter.thumbnailCaption,
         defaultValue: undefined
+      },
+      {
+        name: 'slug',
+        getter: node => node.frontmatter.slug,
+        defaultValue: undefined
       }
     ]
   }
@@ -54,6 +59,8 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
                 node {
                   frontmatter {
                     path
+                    slug
+                    date
                   }
                 }
               }
@@ -66,8 +73,15 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
         const { edges } = result.data.allMarkdownRemark
 
         edges.forEach(edge => {
+          const { date, slug, path } = edge.node.frontmatter;
+          const pathSlug = (path != null) ? path.split('/').pop() : slug
+
+          const parsedDate = new Date(date);
+          const paddedMonth = ('0' + (parsedDate.getMonth()+1)).slice(-2)
+          const path = `/posts/${parsedDate.getFullYear()}/${paddedMonth}/${pathSlug}`
+
           createPage({
-            path: edge.node.frontmatter.path,
+            path,
             component: post,
           })
         })

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "babel-plugin-styled-components": "^1.8.0",
     "gatsby": "^2.0.19",
     "gatsby-image": "^2.0.15",
-    "gatsby-plugin-node-fields": "^2.0.1",
+    "gatsby-plugin-node-fields": "gkcgautam/gatsby-plugin-node-fields#rename-boundActionCreators",
     "gatsby-plugin-offline": "^2.0.11",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-robots-txt": "^1.4.0",

--- a/posts/2019-06-01-stubborn-attachments-tyler-cowen/2019-06-01-stubborn-attachments-tyler-cowen.md
+++ b/posts/2019-06-01-stubborn-attachments-tyler-cowen/2019-06-01-stubborn-attachments-tyler-cowen.md
@@ -2,6 +2,7 @@
 title: "📝 Building A Society of Free, Prosperous and Responsible Individuals" 
 date: "2019-06-02"
 path: "/posts/stubborn-attachments-tyler-cowen"
+slug: "stubborn-attachments-tyler-cowen"
 thumbnail: "cover.jpg"
 ---
 

--- a/src/components/PostList/index.js
+++ b/src/components/PostList/index.js
@@ -46,11 +46,12 @@ const Posts = ({ posts, withExcerpt }) => (
   <Container>
     {posts.map(post => {
       const { excerpt } = post.node;
-      const { title, path, date } = post.node.frontmatter;
+      const { postPath } = post.node.fields;
+      const { title, date } = post.node.frontmatter;
 
       return (
-        <Post key={path}>
-          <PostLink to={path}>
+        <Post key={postPath}>
+          <PostLink to={postPath}>
             <Title>{title}</Title>
             <SubTitle>{date}</SubTitle>
             {withExcerpt &&

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -105,6 +105,9 @@ export const pageQuery = graphql`
       totalCount
       edges {
         node  {
+          fields {
+            postPath
+          }
           frontmatter {
             path
             date(formatString: "Do MMMM YYYY")

--- a/src/pages/posts.js
+++ b/src/pages/posts.js
@@ -33,8 +33,10 @@ export const pageQuery = graphql`
     allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
       edges {
         node {
+          fields {
+            postPath
+          }
           frontmatter {
-            path
             date(formatString: "Do MMMM YYYY")
             title
           }

--- a/src/templates/post.jsx
+++ b/src/templates/post.jsx
@@ -127,14 +127,13 @@ export const pageQuery = graphql`
         siteUrl
       }
     }
-    markdownRemark(frontmatter: { path: { eq: $path } }) {
+    markdownRemark(fields: { postPath: { eq: $path } }) {
       id
       html
       excerpt(pruneLength: 320)
       frontmatter {
         title
         date(formatString: "Do MMMM YYYY")
-        path
         thumbnail{
           childImageSharp {
             fluid(maxWidth: 1000) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5452,10 +5452,9 @@ gatsby-link@^2.0.6:
     "@types/reach__router" "^1.0.0"
     prop-types "^15.6.1"
 
-gatsby-plugin-node-fields@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-node-fields/-/gatsby-plugin-node-fields-2.0.1.tgz#a61fbacecb24b06b21b49e39cc2d438d408f6126"
-  integrity sha512-RxACLZyM6vST7PiIaVXjjZpBxjRiR1CMsi4D4UqiOhO15XAdHoWRa0oJ+8hGbSF6Bx54d+qfMdMuVzZOUUNyMA==
+gatsby-plugin-node-fields@gkcgautam/gatsby-plugin-node-fields#rename-boundActionCreators:
+  version "0.0.6"
+  resolved "https://codeload.github.com/gkcgautam/gatsby-plugin-node-fields/tar.gz/d9542419d37144584071b13d5962c0d6093f4f65"
   dependencies:
     joi "^13.4.0"
     ramda "^0.25.0"


### PR DESCRIPTION
## Change blog URL scheme to include dates
For example, instead of
`https://jurv.is/posts/apple-arcade-news-plus-bundling`
be 
`https://jurv.is/posts/2019/03/apple-arcade-news-plus-bundling`

## Support for slugs+date frontmatter
Instead of writing frontmatter with redundant and ugly values like,
```
---
title: "📝 Building A Society of Free, Prosperous and Responsible Individuals" 
date: "2019-06-02"
path: "/posts/stubborn-attachments-tyler-cowen"
thumbnail: "cover.jpg"
---
```

Allow for just specification of date and slug to generate URL
```
---
title: "📝 Building A Society of Free, Prosperous and Responsible Individuals" 
date: "2019-06-02"
slug: "stubborn-attachments-tyler-cowen"
thumbnail: "cover.jpg"
---
```
and the URL will generate as `https://<ROOT_URL>/posts/2019/06/stubborn-attachments-tyler-cowen"`

## For Future Ref
Code is written to handle legacy frontmatters too so I don't have to go to the individual markdowns and correct them: https://github.com/jurvis/landing/blob/date-organise-slugs/gatsby-node.js#L47